### PR TITLE
Fix golang cds packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ src/go.sum
 Then to create a .cds file:
 
 ```
-./cds --create --lang golang --name fabcarcc --version 1 --output fabcarcc.cds fabcarcc.tgz
+./cds --create --lang golang --name fabcarcc --version 1 --module github.com/hyperledger/fabric-samples/chaincode/fabcar/go --output fabcarcc.cds fabcarcc.tgz
 ```
 
+**Note:** the `--module` option is only required for golang chaincode and must match the module defined in the `go.mod` file
+
 ## Alternatives
+
+### View .cds file contents
 
 The [configtxlator](https://hyperledger-fabric.readthedocs.io/en/release-2.0/commands/configtxlator.html) command can be used to decode .cds files. For example, to list the files inside a .cds file:
 
@@ -65,3 +69,11 @@ jq -j .code_package mysterious.json | base64 --decode | tar -tvf -
 There is another [cdstool](https://github.com/btl5037/cdstool) which you can install using `go get github.com/btl5037/cdstool` assuming you have Go installed and `$GOPATH/bin` on your path
 
 You can also unpack files from a .cds file using [7-Zip](https://www.7-zip.org)
+
+### Create new .cds file
+
+Use the `peer chaincode package` command. For example:
+
+```
+peer chaincode package fabcarcc.cds --lang golang --name fabcarcc --version 1 --path ./fabric-samples/chaincode/fabcar/go
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,6 @@ use clap::{Arg, App};
 use exitfailure::ExitFailure;
 use lib::ChaincodeDeploymentSpecFile;
 use std::path::PathBuf;
-use std::ffi::OsStr;
-
-const NAME: Option<&'static str> = option_env!("CARGO_PKG_NAME");
-const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<(), ExitFailure> {
     let matches = App::new(crate_name!())
@@ -55,6 +51,12 @@ fn main() -> Result<(), ExitFailure> {
             .requires("create")
             .value_name("LANGUAGE")
             .possible_values(&["golang", "java", "node"]))
+        .arg(Arg::with_name("module")
+            .short("m")
+            .long("module")
+            .help("Golang module")
+            .required_if("language", "golang")
+            .value_name("MODULE"))
         .get_matches();
 
     let input_path = PathBuf::from(matches.value_of("INPUT").unwrap());
@@ -68,7 +70,8 @@ fn main() -> Result<(), ExitFailure> {
         let name = matches.value_of("name").unwrap().to_string();
         let version = matches.value_of("version").unwrap().to_string();
         let language = matches.value_of("language").unwrap().to_string();
-        let path = format!("/Users/{}{}/{}", NAME.unwrap_or("cds"), VERSION.unwrap_or(""), input_path.file_stem().unwrap_or(OsStr::new("unknown")).to_string_lossy());
+        let module = matches.value_of("module").unwrap_or("");
+        let path = lib::get_cds_path(&input_path, module);
         let cds = ChaincodeDeploymentSpecFile::new(name, version, language, path, &input_path)?;
 
         let buffer = cds.encode()?;


### PR DESCRIPTION
Golang modules require the cds path value to match the module name

Signed-off-by: James Taylor <jamest@uk.ibm.com>